### PR TITLE
Remove e2e test execution.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
       - run: npx ng build --prod
       - run: npx ng test --watch=false
-      - run: npx ng e2e
+#      - run: npx ng e2e
 
       - run:
           name: Tar & Gzip compiled app

--- a/e2e/protractor.conf.js
+++ b/e2e/protractor.conf.js
@@ -13,6 +13,9 @@ exports.config = {
     './src/**/*.e2e-spec.ts'
   ],
   capabilities: {
+    chromeOptions: {
+      args: [ "--headless" ]
+    },
     browserName: 'chrome'
   },
   directConnect: true,


### PR DESCRIPTION
# Remove e2e test execution

Remove from CircleCi the execution of the e2e tests. Reason being is that on CircleCi the 2e2 tests were failing on things not related to the application tests but due to some misconfiguration regards Chrome and the webdriver.
Moreover, at this point of the development, the team does not write any e2e tests.

Close issue #36.

# Developer Checklist

- [x] If adding new feature(s), added and ran unit tests
- [x] Ran `npm run style:fix` for code style enforcement
- [x] Ran `npm run lint:fix` for linting
- [x] Ran `npm audit` to discover vulnerabilities
