### PR TITLE
Feature/issue 73 implement http interceptor to manage jwt token

### DIFF
--- a/debug.log
+++ b/debug.log
@@ -1,2 +1,0 @@
-[1028/153159.049:ERROR:directory_reader_win.cc(43)] FindFirstFile: Impossibile trovare il percorso specificato. (0x3)
-[1028/160340.870:ERROR:directory_reader_win.cc(43)] FindFirstFile: Impossibile trovare il percorso specificato. (0x3)

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,3 +1,4 @@
+import { HTTP_INTERCEPTORS } from '@angular/common/http'
 import { NgModule } from '@angular/core'
 import { FlexLayoutModule } from '@angular/flex-layout'
 import { BrowserModule } from '@angular/platform-browser'
@@ -6,13 +7,12 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { AppRoutingModule } from './app-routing.module'
 import { AppComponent } from './app.component'
 import { AdvertisementModule } from './modules/core/advertisement/advertisement.module'
+import { AuthHttpInterceptor } from './modules/core/auth/auth-http-interceptor'
 import { InMemoryAuthService } from './modules/core/auth/auth-in-memory.service'
 import { AuthService } from './modules/core/auth/auth.service'
 import { MaterialModule } from './modules/shared/material.module'
 import { LogoutComponent } from './shared/components/logout/logout.component'
 import { PageNotFoundComponent } from './shared/components/pagenotfound/pagenotfound.component'
-import { HTTP_INTERCEPTORS } from '@angular/common/http'
-import { AuthHttpInterceptor } from './modules/core/auth/auth-http-interceptor'
 
 const appComponents = [AppComponent, PageNotFoundComponent, LogoutComponent]
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,8 @@ import { AuthService } from './modules/core/auth/auth.service'
 import { MaterialModule } from './modules/shared/material.module'
 import { LogoutComponent } from './shared/components/logout/logout.component'
 import { PageNotFoundComponent } from './shared/components/pagenotfound/pagenotfound.component'
+import { HTTP_INTERCEPTORS } from '@angular/common/http'
+import { AuthHttpInterceptor } from './modules/core/auth/auth-http-interceptor'
 
 const appComponents = [AppComponent, PageNotFoundComponent, LogoutComponent]
 
@@ -28,6 +30,11 @@ const appComponents = [AppComponent, PageNotFoundComponent, LogoutComponent]
     {
       provide: AuthService,
       useClass: InMemoryAuthService,
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: AuthHttpInterceptor,
+      multi: true,
     },
   ],
   bootstrap: [AppComponent],

--- a/src/app/modules/core/auth/auth-http-interceptor.spec.ts
+++ b/src/app/modules/core/auth/auth-http-interceptor.spec.ts
@@ -1,9 +1,9 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { TestBed } from '@angular/core/testing'
+import { Router } from '@angular/router'
 
 import { AuthHttpInterceptor } from './auth-http-interceptor'
 import { AuthService } from './auth.service'
-import { Router } from '@angular/router'
-import { HttpClientTestingModule } from '@angular/common/http/testing'
 
 describe('AuthHttpInterceptorService', () => {
   let service: AuthHttpInterceptor

--- a/src/app/modules/core/auth/auth-http-interceptor.spec.ts
+++ b/src/app/modules/core/auth/auth-http-interceptor.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing'
+
+import { AuthHttpInterceptor } from './auth-http-interceptor'
+
+describe('AuthHttpInterceptorService', () => {
+  let service: AuthHttpInterceptor
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({})
+    service = TestBed.inject(AuthHttpInterceptor)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+})

--- a/src/app/modules/core/auth/auth-http-interceptor.spec.ts
+++ b/src/app/modules/core/auth/auth-http-interceptor.spec.ts
@@ -1,12 +1,25 @@
 import { TestBed } from '@angular/core/testing'
 
 import { AuthHttpInterceptor } from './auth-http-interceptor'
+import { AuthService } from './auth.service'
+import { Router } from '@angular/router'
+import { HttpClientTestingModule } from '@angular/common/http/testing'
 
 describe('AuthHttpInterceptorService', () => {
   let service: AuthHttpInterceptor
 
+  const authServiceSpy = jasmine.createSpyObj('AuthService', ['getToken'])
+  const routerSpy = jasmine.createSpyObj('Router', ['navigate'])
+
   beforeEach(() => {
-    TestBed.configureTestingModule({})
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        AuthHttpInterceptor,
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    })
     service = TestBed.inject(AuthHttpInterceptor)
   })
 

--- a/src/app/modules/core/auth/auth-http-interceptor.ts
+++ b/src/app/modules/core/auth/auth-http-interceptor.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core'
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http'
+import { Observable, throwError } from 'rxjs'
+import { AuthService } from './auth.service'
+import { Router } from '@angular/router'
+import { catchError } from 'rxjs/operators'
+
+@Injectable()
+export class AuthHttpInterceptor implements HttpInterceptor {
+  constructor(private authService: AuthService, private router: Router) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const jwtToken = this.authService.getToken()
+    const authRequest = req.clone({
+      setHeaders: { authorization: `Bearer: ${jwtToken}` },
+    })
+    return next.handle(authRequest).pipe(
+      catchError((err, caught) => {
+        if (err.status === 401) {
+          this.router.navigate(['/login'], {
+            queryParams: { redirectUrl: this.router.routerState.snapshot.url },
+          })
+        }
+        return throwError(err)
+      })
+    )
+  }
+}

--- a/src/app/modules/core/auth/auth-http-interceptor.ts
+++ b/src/app/modules/core/auth/auth-http-interceptor.ts
@@ -1,14 +1,15 @@
-import { Injectable } from '@angular/core'
 import {
   HttpEvent,
   HttpHandler,
   HttpInterceptor,
   HttpRequest,
 } from '@angular/common/http'
-import { Observable, throwError } from 'rxjs'
-import { AuthService } from './auth.service'
+import { Injectable } from '@angular/core'
 import { Router } from '@angular/router'
+import { Observable, throwError } from 'rxjs'
 import { catchError } from 'rxjs/operators'
+
+import { AuthService } from './auth.service'
 
 @Injectable()
 export class AuthHttpInterceptor implements HttpInterceptor {


### PR DESCRIPTION
# JWT Token Http Interceptor

_Create a HTTP interceptor in order to add the JWT token as a HTTP header for remote requests._

# Developer Checklist

- [ ] Updated documentation or README.md
- [x] If adding new feature(s), added and ran unit tests
- [ ] If create new release, bumped version number
- [x] Ran `npm run style:fix` for code style enforcement
- [x] Ran `npm run lint:fix` for linting
- [ ] Ran `npm audit` to discover vulnerabilities
