### PR TITLE
Feature/issue 177 slideshow images in the advertisement card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10137,6 +10137,21 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "ng-image-slider": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/ng-image-slider/-/ng-image-slider-2.6.4.tgz",
+      "integrity": "sha512-7FxHi0I0Z9hOkKAWmofcBbDOB7j8W5e6j6TY/gTyOyb06zbgbFSYyunNbxoiY+anEn+N2UL+sQxnYw9zCKsm5A==",
+      "requires": {
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "jwt-decode": "^3.0.0",
     "lodash": "^4.17.20",
     "moment": "^2.29.1",
+    "ng-image-slider": "^2.6.4",
     "rxjs": "~6.6.3",
     "subsink": "^1.0.1",
     "tslib": "^2.0.0",

--- a/src/app/modules/core/advertisement/components/card/card-top/card-main-container/card-main-container.component.html
+++ b/src/app/modules/core/advertisement/components/card/card-top/card-main-container/card-main-container.component.html
@@ -4,7 +4,7 @@
     <mat-card-content fxLayout fxLayout.xs="column" fxLayoutAlign="space-between"
       fxLayoutWrap="wrap">
 
-      <cav-photogallery [photo]="advertisement?.property?.images[0]?.image">
+      <cav-photogallery [imageObject]="advertisement?.property?.images">
       </cav-photogallery>
 
       <div fxLayout="column">

--- a/src/app/modules/core/advertisement/components/card/card-top/card-main-container/card-main-container.component.html
+++ b/src/app/modules/core/advertisement/components/card/card-top/card-main-container/card-main-container.component.html
@@ -4,7 +4,7 @@
     <mat-card-content fxLayout fxLayout.xs="column" fxLayoutAlign="space-between"
       fxLayoutWrap="wrap">
 
-      <cav-photogallery [imageObject]="advertisement?.property?.images">
+      <cav-photogallery [images]="advertisement?.property?.images">
       </cav-photogallery>
 
       <div fxLayout="column">

--- a/src/app/modules/core/advertisement/components/card/card-top/card-main-container/card-main-container.component.html
+++ b/src/app/modules/core/advertisement/components/card/card-top/card-main-container/card-main-container.component.html
@@ -4,7 +4,7 @@
     <mat-card-content fxLayout fxLayout.xs="column" fxLayoutAlign="space-between"
       fxLayoutWrap="wrap">
 
-      <cav-photogallery [photo]="advertisement?.property?.imagesPath">
+      <cav-photogallery [photo]="advertisement?.property?.images[0]?.image">
       </cav-photogallery>
 
       <div fxLayout="column">

--- a/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.html
+++ b/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.html
@@ -1,4 +1,5 @@
 <div class="photo-gallery">
-  <ng-image-slider [images]="imageObject" [showArrow]="false">
+  <ng-image-slider [images]="images" [showArrow]="false"
+    [imageSize]="{width: '180px', height: '120px'}">
   </ng-image-slider>
 </div>

--- a/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.html
+++ b/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.html
@@ -1,3 +1,4 @@
 <div class="photo-gallery">
-  <img src="{{photo}}" alt="Casa">
+  <ng-image-slider [images]="imageObject" [showArrow]="false">
+  </ng-image-slider>
 </div>

--- a/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.ts
+++ b/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core'
-
-import { IPicture } from './../../../../../../../shared/models/property'
+import { IPicture } from '@shared/models/property'
 
 @Component({
   selector: 'cav-photogallery',

--- a/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.ts
+++ b/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.ts
@@ -6,7 +6,7 @@ import { Component, Input, OnInit } from '@angular/core'
   styleUrls: ['./photogallery.component.scss'],
 })
 export class PhotogalleryComponent implements OnInit {
-  @Input() photo: string
+  @Input() imageObject: Array<object>
   constructor() {}
 
   ngOnInit(): void {}

--- a/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.ts
+++ b/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.ts
@@ -7,17 +7,20 @@ import { IPicture } from '@shared/models/property'
   styleUrls: ['./photogallery.component.scss'],
 })
 export class PhotogalleryComponent implements OnInit {
-  @Input() images: Array<IPicture>
+  @Input() images: IPicture[]
   constructor() {}
 
   ngOnInit(): void {
-    if (this.images !== undefined && !this?.images?.length) {
-      this.images[0] = {
-        image: 'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
-        thumbImage:
-          'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
-        alt: 'No image',
-      }
+    if (!this?.images?.length) {
+      this.images = [
+        {
+          image:
+            'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
+          thumbImage:
+            'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
+          alt: 'No image',
+        },
+      ]
     }
   }
 }

--- a/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.ts
+++ b/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core'
-import { IPicture } from '@shared/models/property'
+
+import { IPicture } from './../../../../../../../shared/models/property'
 
 @Component({
   selector: 'cav-photogallery',
@@ -7,12 +8,15 @@ import { IPicture } from '@shared/models/property'
   styleUrls: ['./photogallery.component.scss'],
 })
 export class PhotogalleryComponent implements OnInit {
-  @Input() images: IPicture[]
+  // tslint:disable-next-line: variable-name
+  private _images: IPicture[]
   constructor() {}
 
-  ngOnInit(): void {
-    if (!this?.images?.length) {
-      this.images = [
+  ngOnInit(): void {}
+
+  @Input() set images(images: IPicture[]) {
+    if (!images?.length) {
+      this._images = [
         {
           image:
             'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
@@ -21,6 +25,12 @@ export class PhotogalleryComponent implements OnInit {
           alt: 'No image',
         },
       ]
+    } else {
+      this._images = images
     }
+  }
+
+  get images(): IPicture[] {
+    return this._images
   }
 }

--- a/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.ts
+++ b/src/app/modules/core/advertisement/components/card/card-top/photogallery/photogallery.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core'
+import { IPicture } from '@shared/models/property'
 
 @Component({
   selector: 'cav-photogallery',
@@ -6,8 +7,17 @@ import { Component, Input, OnInit } from '@angular/core'
   styleUrls: ['./photogallery.component.scss'],
 })
 export class PhotogalleryComponent implements OnInit {
-  @Input() imageObject: Array<object>
+  @Input() images: Array<IPicture>
   constructor() {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    if (this.images !== undefined && !this?.images?.length) {
+      this.images[0] = {
+        image: 'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
+        thumbImage:
+          'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
+        alt: 'No image',
+      }
+    }
+  }
 }

--- a/src/app/modules/core/advertisement/components/latest/latest-container/latest-container.component.html
+++ b/src/app/modules/core/advertisement/components/latest/latest-container/latest-container.component.html
@@ -6,7 +6,7 @@
     </button>
 
     <cav-latest-mini-card *ngFor="let advertisement of latestAdvertisements | async"
-      [advertisement]="advertisement">
+      [advertisement]="advertisement" [images]="advertisement?.property?.images">
     </cav-latest-mini-card>
 
     <button class="arrow-button">

--- a/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.html
+++ b/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.html
@@ -1,5 +1,7 @@
 <mat-card routerLink="{{advertisement?.id}}" class="mini-card">
-  <img mat-card-image src="{{ images[0]?.image }}">
+  <div *ngIf="images && images[0]">
+    <img mat-card-image src="{{ images[0]?.image }}">
+  </div>
   <mat-card-content>
     <mat-card-title>
       <h3> {{advertisement?.property?.title }} a

--- a/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.html
+++ b/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.html
@@ -1,5 +1,5 @@
 <mat-card routerLink="{{advertisement?.id}}" class="mini-card">
-  <img mat-card-image src="{{ advertisement?.property?.images[0]?.image }}">
+  <img mat-card-image src="{{ images[0]?.image }}">
   <mat-card-content>
     <mat-card-title>
       <h3> {{advertisement?.property?.title }} a

--- a/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.html
+++ b/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.html
@@ -1,5 +1,5 @@
 <mat-card routerLink="{{advertisement?.id}}" class="mini-card">
-  <img mat-card-image src="{{ advertisement?.property?.imagesPath[0] }}">
+  <img mat-card-image src="{{ advertisement?.property?.images[0]?.image }}">
   <mat-card-content>
     <mat-card-title>
       <h3> {{advertisement?.property?.title }} a

--- a/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.scss
+++ b/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.scss
@@ -2,3 +2,8 @@
   width: 200px;
   height: auto;
 }
+
+img.mat-card-image {
+  width: 230px;
+  height: 160px;
+}

--- a/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.ts
+++ b/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core'
 import { IMockAdvertisement } from '@modules/core/advertisement/mock-advertisement/mock-advertisement'
+import { IPicture } from '@shared/models/property'
 
 @Component({
   selector: 'cav-latest-mini-card',
@@ -8,20 +9,20 @@ import { IMockAdvertisement } from '@modules/core/advertisement/mock-advertiseme
 })
 export class LatestMiniCardComponent implements OnInit {
   @Input() advertisement: IMockAdvertisement
-
+  @Input() images: IPicture[]
   constructor() {}
 
   ngOnInit(): void {
-    if (
-      this.advertisement !== undefined &&
-      !this.advertisement?.property?.images?.length
-    ) {
-      this.advertisement.property.images[0] = {
-        image: 'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
-        thumbImage:
-          'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
-        alt: 'No image',
-      }
+    if (!this.images?.length) {
+      this.images = [
+        {
+          image:
+            'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
+          thumbImage:
+            'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
+          alt: 'No image',
+        },
+      ]
     }
   }
 }

--- a/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.ts
+++ b/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.ts
@@ -11,5 +11,17 @@ export class LatestMiniCardComponent implements OnInit {
 
   constructor() {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    if (
+      this.advertisement !== undefined &&
+      !this.advertisement?.property?.images?.length
+    ) {
+      this.advertisement.property.images[0] = {
+        image: 'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
+        thumbImage:
+          'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
+        alt: 'No image',
+      }
+    }
+  }
 }

--- a/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.ts
+++ b/src/app/modules/core/advertisement/components/latest/latest-mini-card/latest-mini-card.component.ts
@@ -9,12 +9,15 @@ import { IPicture } from '@shared/models/property'
 })
 export class LatestMiniCardComponent implements OnInit {
   @Input() advertisement: IMockAdvertisement
-  @Input() images: IPicture[]
+  // tslint:disable-next-line: variable-name
+  private _images: IPicture[]
   constructor() {}
 
-  ngOnInit(): void {
-    if (!this.images?.length) {
-      this.images = [
+  ngOnInit(): void {}
+
+  @Input() set images(images: IPicture[]) {
+    if (!images?.length) {
+      this._images = [
         {
           image:
             'https://cdn.pixabay.com/photo/2017/03/20/20/59/home-2160318_960_720.png',
@@ -23,6 +26,12 @@ export class LatestMiniCardComponent implements OnInit {
           alt: 'No image',
         },
       ]
+    } else {
+      this._images = images
     }
+  }
+
+  get images(): IPicture[] {
+    return this._images
   }
 }

--- a/src/app/modules/core/advertisement/mock-advertisement/mock-advertisement.ts
+++ b/src/app/modules/core/advertisement/mock-advertisement/mock-advertisement.ts
@@ -100,6 +100,12 @@ export const MOCKADVERTISEMENTS_MOCK_DATA: IMockAdvertisement[] = [
           title: 'Splendido monovano',
           alt: 'Salotto',
         },
+        {
+          image: 'https://cdn.pixabay.com/photo/2014/08/11/21/40/wall-416062_960_720.jpg',
+          thumbImage: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
+          title: 'Splendido monovano',
+          alt: 'Camera da letto',
+        },
       ],
       status: Status.Open,
     },

--- a/src/app/modules/core/advertisement/mock-advertisement/mock-advertisement.ts
+++ b/src/app/modules/core/advertisement/mock-advertisement/mock-advertisement.ts
@@ -93,7 +93,14 @@ export const MOCKADVERTISEMENTS_MOCK_DATA: IMockAdvertisement[] = [
         shower: true,
         bath: false,
       },
-      imagesPath: ['https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg'],
+      images: [
+        {
+          image: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
+          thumbImage: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
+          title: 'Splendido monovano',
+          alt: 'Salotto',
+        },
+      ],
       status: Status.Open,
     },
     reviews: [
@@ -167,7 +174,14 @@ export const MOCKADVERTISEMENTS_MOCK_DATA: IMockAdvertisement[] = [
         shower: true,
         bath: false,
       },
-      imagesPath: ['https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg'],
+      images: [
+        {
+          image: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
+          thumbImage: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
+          title: 'Splendido appartamento',
+          alt: 'Salotto',
+        },
+      ],
       status: Status.Open,
     },
     reviews: [
@@ -231,8 +245,15 @@ export const MOCKADVERTISEMENTS_MOCK_DATA: IMockAdvertisement[] = [
         shower: true,
         bath: true,
       },
-      imagesPath: [
-        'https://www.grossoandpartners.com/docs/immobili/1925/foto/A126-Attici-Mansarde-Treviso-Treviso-77491.jpeg',
+      images: [
+        {
+          image:
+            'https://www.grossoandpartners.com/docs/immobili/1925/foto/A126-Attici-Mansarde-Treviso-Treviso-77491.jpeg',
+          thumbImage:
+            'https://www.grossoandpartners.com/docs/immobili/1925/foto/A126-Attici-Mansarde-Treviso-Treviso-77491.jpeg',
+          title: 'Splendido attico con vista',
+          alt: 'Terrazza',
+        },
       ],
       status: Status.Open,
     },

--- a/src/app/modules/core/advertisement/mock-advertisement/mock-advertisement.ts
+++ b/src/app/modules/core/advertisement/mock-advertisement/mock-advertisement.ts
@@ -97,13 +97,12 @@ export const MOCKADVERTISEMENTS_MOCK_DATA: IMockAdvertisement[] = [
         {
           image: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
           thumbImage: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
-          title: 'Splendido monovano',
           alt: 'Salotto',
         },
         {
-          image: 'https://cdn.pixabay.com/photo/2014/08/11/21/40/wall-416062_960_720.jpg',
-          thumbImage: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
-          title: 'Splendido monovano',
+          image: 'https://cdn.pixabay.com/photo/2016/11/19/13/06/bed-1839184_960_720.jpg',
+          thumbImage:
+            'https://cdn.pixabay.com/photo/2016/11/19/13/06/bed-1839184_960_720.jpg',
           alt: 'Camera da letto',
         },
       ],
@@ -184,7 +183,6 @@ export const MOCKADVERTISEMENTS_MOCK_DATA: IMockAdvertisement[] = [
         {
           image: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
           thumbImage: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
-          title: 'Splendido appartamento',
           alt: 'Salotto',
         },
       ],
@@ -257,7 +255,6 @@ export const MOCKADVERTISEMENTS_MOCK_DATA: IMockAdvertisement[] = [
             'https://www.grossoandpartners.com/docs/immobili/1925/foto/A126-Attici-Mansarde-Treviso-Treviso-77491.jpeg',
           thumbImage:
             'https://www.grossoandpartners.com/docs/immobili/1925/foto/A126-Attici-Mansarde-Treviso-Treviso-77491.jpeg',
-          title: 'Splendido attico con vista',
           alt: 'Terrazza',
         },
       ],

--- a/src/app/modules/shared/shared.module.ts
+++ b/src/app/modules/shared/shared.module.ts
@@ -3,9 +3,15 @@ import { FlexLayoutModule } from '@angular/flex-layout'
 import { ReactiveFormsModule } from '@angular/forms'
 import { MaterialModule } from '@modules/shared/material.module'
 import { DialogComponent } from '@shared/components/dialog/dialog.component'
+import { NgImageSliderModule } from 'ng-image-slider'
 
 const sharedComponents = [DialogComponent]
-const sharedModules = [FlexLayoutModule, MaterialModule, ReactiveFormsModule]
+const sharedModules = [
+  FlexLayoutModule,
+  MaterialModule,
+  ReactiveFormsModule,
+  NgImageSliderModule,
+]
 
 @NgModule({
   declarations: [...sharedComponents],

--- a/src/app/shared/models/mock-data/data.ts
+++ b/src/app/shared/models/mock-data/data.ts
@@ -241,7 +241,6 @@ export const PROPERTIES_MOCK_DATA: Property[] = [
       {
         image: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
         thumbImage: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
-        title: 'Splendido monovano',
         alt: 'Salotto',
       },
     ],
@@ -279,7 +278,6 @@ export const PROPERTIES_MOCK_DATA: Property[] = [
       {
         image: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
         thumbImage: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
-        title: 'Splendido appartamento',
         alt: 'Salotto',
       },
     ],
@@ -318,7 +316,6 @@ export const PROPERTIES_MOCK_DATA: Property[] = [
           'https://www.grossoandpartners.com/docs/immobili/1925/foto/A126-Attici-Mansarde-Treviso-Treviso-77491.jpeg',
         thumbImage:
           'https://www.grossoandpartners.com/docs/immobili/1925/foto/A126-Attici-Mansarde-Treviso-Treviso-77491.jpeg',
-        title: 'Splendido attico con vista',
         alt: 'Terrazza',
       },
     ],

--- a/src/app/shared/models/mock-data/data.ts
+++ b/src/app/shared/models/mock-data/data.ts
@@ -237,7 +237,14 @@ export const PROPERTIES_MOCK_DATA: Property[] = [
       shower: true,
       bath: false,
     },
-    imagesPath: ['https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg'],
+    images: [
+      {
+        image: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
+        thumbImage: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
+        title: 'Splendido monovano',
+        alt: 'Salotto',
+      },
+    ],
     status: Status.Open,
   },
   {
@@ -268,7 +275,14 @@ export const PROPERTIES_MOCK_DATA: Property[] = [
       shower: true,
       bath: false,
     },
-    imagesPath: ['https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg'],
+    images: [
+      {
+        image: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
+        thumbImage: 'https://cf.bstatic.com/images/hotel/max1024x768/228/228549673.jpg',
+        title: 'Splendido appartamento',
+        alt: 'Salotto',
+      },
+    ],
     status: Status.Open,
   },
   {
@@ -298,8 +312,15 @@ export const PROPERTIES_MOCK_DATA: Property[] = [
       shower: true,
       bath: true,
     },
-    imagesPath: [
-      'https://www.grossoandpartners.com/docs/immobili/1925/foto/A126-Attici-Mansarde-Treviso-Treviso-77491.jpeg',
+    images: [
+      {
+        image:
+          'https://www.grossoandpartners.com/docs/immobili/1925/foto/A126-Attici-Mansarde-Treviso-Treviso-77491.jpeg',
+        thumbImage:
+          'https://www.grossoandpartners.com/docs/immobili/1925/foto/A126-Attici-Mansarde-Treviso-Treviso-77491.jpeg',
+        title: 'Splendido attico con vista',
+        alt: 'Terrazza',
+      },
     ],
     status: Status.Open,
   },

--- a/src/app/shared/models/property.ts
+++ b/src/app/shared/models/property.ts
@@ -18,10 +18,10 @@ export interface IRoom {
   mq: number
 }
 
-export interface IImage {
+export interface IPicture {
   image: string
   thumbImage: string
-  title: string
+  title?: string
   alt: string
 }
 
@@ -35,7 +35,7 @@ export interface IProperty {
   numberOfToilet: number
   description: string
   facilities: IFacilities
-  images: IImage[]
+  images: IPicture[]
   status: Status
 }
 

--- a/src/app/shared/models/property.ts
+++ b/src/app/shared/models/property.ts
@@ -18,6 +18,13 @@ export interface IRoom {
   mq: number
 }
 
+export interface IImage {
+  image: string
+  thumbImage: string
+  title: string
+  alt: string
+}
+
 export interface IProperty {
   id: number
   landlordId: number
@@ -28,7 +35,7 @@ export interface IProperty {
   numberOfToilet: number
   description: string
   facilities: IFacilities
-  imagesPath: string[]
+  images: IImage[]
   status: Status
 }
 
@@ -43,7 +50,7 @@ export class Property implements IProperty {
     public numberOfToilet = null,
     public description = null,
     public facilities = null,
-    public imagesPath = null,
+    public images = null,
     public status = null
   ) {}
 
@@ -61,7 +68,7 @@ export class Property implements IProperty {
       property.numberOfToilet,
       property.description,
       property.facilities,
-      property.imagesPath,
+      property.images,
       property.status
     )
   }


### PR DESCRIPTION
# Feature/issue 177 slideshow images in the advertisement card

Create a slideshow for images. When te user click the image a lightbox will open which will display all images for that property.

# Developer Checklist

- [ ] Updated documentation or README.md
- [ ] If adding new feature(s), added and ran unit tests
- [ ] If create new release, bumped version number
- [x] Ran `npm run style:fix` for code style enforcement
- [x] Ran `npm run lint:fix` for linting
- [ ] Ran `npm audit` to discover vulnerabilities
